### PR TITLE
Removed ambiguity in _coord initialisation

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -33,7 +33,7 @@ const std::optional<_smartMoveData> game::isMovePossible(std::shared_ptr<ludo_go
 	if( dist == 0 )
 		return {};
 
-	_coord increment_coord({ 0, 0 });
+	_coord increment_coord(0, 0);
 	_coord updated_coords(the_goti->curr_coords);
 	Direction turnDirection, currDirection = the_goti->curr_direction;
 


### PR DESCRIPTION
The brace-separated initialiser could be considered an std::pair, or an implicit _coord